### PR TITLE
Fix the IDA debug module caused by refresh_debugger_memory is always …

### DIFF
--- a/dereferencing/dbg.py
+++ b/dereferencing/dbg.py
@@ -56,7 +56,7 @@ class DbgHooks(idaapi.DBG_Hooks):
         return self.timer_freq
 
     def notify(self):
-        idaapi.refresh_debugger_memory()
+        #idaapi.refresh_debugger_memory()
         self.callback()
 
     def dbg_step_into(self):

--- a/dereferencing/views/stack.py
+++ b/dereferencing/views/stack.py
@@ -51,12 +51,19 @@ class StackViewer(CustViewer):
         ea = self.get_current_expr_ea()
         if not ea or not idaapi.is_loaded(ea):
             return
-        stack_val = ida_bytes.get_dword(ea)
+        stack_val = 0
+        if idaapi.inf_is_64bit():
+            stack_val = ida_bytes.get_qword(ea)
+        else:
+            stack_val = ida_bytes.get_dword(ea)
         b = idaapi.ask_str("0x%X" % stack_val, 0, "Modify value")
         if b is not None:
             try:
                 value = int(idaapi.str2ea(b))
-                idc.patch_dword(ea, value)
+                if idaapi.inf_is_64bit():
+                    idc.patch_qword(ea, value)
+                else:
+                    idc.patch_dword(ea, value)
                 self.reload_info()
             except:
                 idaapi.warning("Invalid expression")

--- a/dereferencing/views/stack.py
+++ b/dereferencing/views/stack.py
@@ -6,6 +6,7 @@
 
 import idc
 import idaapi
+import ida_bytes
 
 from dereferencing import dbg, config, actions
 
@@ -46,6 +47,20 @@ class StackViewer(CustViewer):
             return True
         return False
 
+    def modify_value(self):
+        ea = self.get_current_expr_ea()
+        if not ea or not idaapi.is_loaded(ea):
+            return
+        stack_val = ida_bytes.get_dword(ea)
+        b = idaapi.ask_str("0x%X" % stack_val, 0, "Modify value")
+        if b is not None:
+            try:
+                value = int(idaapi.str2ea(b))
+                idc.patch_dword(ea, value)
+                self.reload_info()
+            except:
+                idaapi.warning("Invalid expression")
+                
     def can_edit_line(self):
         return True
 
@@ -56,6 +71,7 @@ class StackViewer(CustViewer):
             actions.MenuAction("s_jump_new_window",  self.jump_in_new_window,  "Jump in a new window", None, "Ctrl-J",    125),
             actions.MenuAction("s_jump_hex",         self.jump_in_hex,         "Jump in hex",          None, "X",         89),
             actions.MenuAction("s_jump_to",          self.jump_to,             "Sync with expr",       shortcut="G", icon=124),
+            actions.MenuAction("s_modify_value",     self.modify_value,        "Modify value",         None, "E",         104),
             actions.MenuAction("s_stack_entries",    self.set_stack_entries,   "Stack entries"),
             actions.MenuAction("-"),
         ])


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/5970455/67363999-3c329b00-f5a1-11e9-8fce-d44961cede5b.gif)
