### PR TITLE
add support for py3 on IDA 7.4

### DIFF
--- a/dereferencing/colorizer.py
+++ b/dereferencing/colorizer.py
@@ -191,7 +191,10 @@ class Colorizer(object):
             return all(ord(c) < 127 and ord(c) >= 32 for c in s)
 
     def is_printable(self, s):
-        return all(c in string.printable for c in s)
+        if sys.version_info >= (3, 0):
+            return all(chr(c) in string.printable for c in s)
+        else:
+            return all(c in string.printable for c in s)
 
     def strip_disas_spaces(self, d):
         return re.sub(' +', ' ', d)

--- a/dereferencing/colorizer.py
+++ b/dereferencing/colorizer.py
@@ -5,6 +5,7 @@
 #
 
 import re
+import sys
 import string
 
 import idc
@@ -184,7 +185,10 @@ class Colorizer(object):
         return idc.is_code(flags)
 
     def is_ascii(self, s):
-        return all(ord(c) < 127 and ord(c) >= 32 for c in s)
+        if sys.version_info >= (3, 0):
+            return all(c < 127 and c >= 32 for c in s)
+        else:
+            return all(ord(c) < 127 and ord(c) >= 32 for c in s)
 
     def is_printable(self, s):
         return all(c in string.printable for c in s)
@@ -206,7 +210,7 @@ class Colorizer(object):
         return res
 
     def get_printable(self, val):
-        packed = dbg.pack(val).replace('\x00', '')
+        packed = dbg.pack(val).replace(b'\x00', b'')
         if len(packed) > 0 and self.is_ascii(packed):
             return self.as_comment(' /* %s */' % repr(packed))
         return ''

--- a/dereferencing/regs.py
+++ b/dereferencing/regs.py
@@ -22,7 +22,7 @@ class RegisterSet(object):
         self.flagsr = flagsr
         self.args = args
         self.all = common + (frame, stack, pc, flagsr)
-        self.all = filter(None, self.all)
+        self.all = list(filter(None, self.all))
         self.max_len = max(map(len, self.all))
 
     def __len__(self):


### PR DESCRIPTION
Adds support for py3 on IDA 7.4.

Unfortunately, I don't have a py2 install, so I can't test this. However, I *think* this should be just fine.