### PR TITLE
Segments null check

### DIFF
--- a/dereferencing/colorizer.py
+++ b/dereferencing/colorizer.py
@@ -37,7 +37,7 @@ def get_value_type(ea):
     is_code = idc.is_code(flags)
 
     if "stack" in segm_name.lower() or \
-    (dbg.stack_segm and dbg.stack_segm.start_ea == segm.start_ea):
+    (dbg.stack_segm and segm and dbg.stack_segm.start_ea == segm.start_ea):
         addr_type = T_STACK
 
     elif "heap" in segm_name.lower():


### PR DESCRIPTION
I've added a simple null check to prevent errors when using other plugins that move/change the debugger segments.