### PR TITLE
add ida-plugin.json

### DIFF
--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -1,0 +1,40 @@
+{
+  "IDAMetadataDescriptorVersion": 1,
+  "plugin": {
+    "name": "deREferencing",
+    "entryPoint": "dereferencing.py",
+    "version": "2025.9.24",
+    "idaVersions": ">=7.1",
+    "description": "New registers and stack views with dereferenced pointers, colors and other useful information",
+    "license": "GPL-3.0",
+    "categories": [
+      "debugging-and-tracing",
+      "ui-ux-and-visualization"
+    ],
+    "urls": {
+      "repository": "https://github.com/danigargu/deREferencing"
+    },
+    "authors": [
+      {
+        "name": "Daniel García",
+        "email": "danigargu@gmail.com"
+      }
+    ],
+    "keywords": [
+      "debugging",
+      "registers",
+      "stack-view",
+      "pointer-dereferencing",
+      "gdb-like",
+      "visualization",
+      "memory-analysis",
+      "reverse-engineering",
+      "x86",
+      "x86-64",
+      "arm",
+      "arm64",
+      "mips32",
+      "mips64"
+    ]
+  }
+}


### PR DESCRIPTION
tl;dr: add `ida-plugin.json` for inclusion in upcoming IDA Pro plugin manager ecosystem.

---

Hex-Rays is introducing a plugin manager for IDA Pro, and we'd like to include deREferencing. It will make discovering, installing, and configuring IDA Pro plugins a snap - think apt-get, pip, or npm but for IDA Pro. Initially the plugin manager will be invoked through the [HCLI command line utility](https://hcli.docs.hex-rays.com/), the official Hex-Rays tool for managing IDA Pro installations, licenses, and SDKs. We're also working to bring the plugin repository directly into the IDA Pro GUI, much like the VS Code Extension marketplace.

The implementation of the plugin manager via HCLI is complete (though perhaps can use some polishing - we'll see), and we're now migrating plugins and documentation. We'll shortly introduce the plugin manager on the Hex-Rays blog and recommend all users to try it out. We'd love to include your plugins in the ecosystem :-)

The plugin manager, and updated https://plugins.hex-rays.com/, relies on the `ida-plugin.json` metadata file. We've introduced a few changes to this file format to ensure users can discover plugins and install them smoothly. Notably, the plugin manager will install Python dependencies for you! We believe that most plugins can now be installed without any manual steps (copy files to `$IDAUSR/plugins`, edit source code, run pip commands, etc.). Instead, you'll do a simple `hcli plugin install deREferencing`.

Since we're asking for changes to your plugin, we're serious about lending support to make it easier. Please don't hesitate to reach out if you need help, have ideas, or notice a bug. We can open PRs against your project, fix HCLI, and tweak the metadata format based on your feedback. Also happy to schedule a video call together (or physically meet near Frankfurt, Germany or Liège, Belgium). Ultimately, the plugin manager should make it much easier for users to upgrade their IDA Pro experience, while also introducing more users to your plugin.

So, to ensure your plugin works with the new ecosystem, we recommend:

1. install HCLI, since it has a linter for plugins. Instructions are [here](https://hcli.docs.hex-rays.com/), but they boil down to:
   a. `curl -LsSf https://hcli.docs.hex-rays.com/install | sh`, or
   b. `iwr -useb https://hcli.docs.hex-rays.com/install.ps1 | iex`, or
   c. if you insist, without installation: `uv run --with ida-hcli hcli` 
2. (done in this PR) update `ida-plugin.json` according to [updated guidelines here](https://github.com/HexRaysSA/ida-hcli/blob/main/docs/reference/plugin-packaging-and-format.md), which include:
   a. `.plugin.version` is now required
   b. `.plugin.urls.repository` is added and required
   c. `.plugin.author` is added and required
   d. furthermore, you can also add `.plugin.pythonDependencies`, specify `.plugin.keywords` for better discovery via searches, `.plugin.platforms` to limit support to Windows, macOS, and/or Linux, or  `.plugin.license` to specify a license.
   e. use `hcli plugin lint /path/to/plugin/directory/with/ida-plugin.json` to check for critical issues or optional recommendations in the plugin metadata. And `hcli plugin lint /path/to/plugin.zip` to check for issues with the release archive.
3. plan to distribute plugins via ZIP archives. Collect the plugin files (Python source or `.dll`/`.so`/`.dylib` shared objects) and the `ida-plugin.json` and any other supporting files into a single file. 
   a. For pure-Python plugins, you can probably rely on the source archive automatically attached to GitHub Releases and Tags. 
   b. For native plugins, you should consider using GitHub Actions to build the artifacts - and Hex-Rays is happy to provide templates and/or propose an initial workflow. You can see an example here: [williballenthin/zydisinfo .../build.yml](https://github.com/williballenthin/zydisinfo/blob/gha-hcli/.github/workflows/build.yml)
4. use GitHub Releases to tag releases, because the plugin repository backend (initially) uses GitHub to discover and index available plugins.
   a. each day, an indexer looks for repositories that contain `ida-plugin.json` and inspects the releases for candidate plugins. So once you've updated the metadata file and made a new release in GitHub, your plugin will soon show up automatically!

For most plugins, these changes shouldn't take very long, but if you have any trouble or confusion - please tell us and we'll lend a hand. Once everything is working, users will be able to do:

```console
hcli plugin search deREferencing
hcli plugin install deREferencing
hcli plugin upgrade deREferencing
hcli plugin uninstall deREferencing
```

With all that in mind, would you please consider updating your plugin to work with the new IDA Pro plugin manager ecosystem? If you need help, guidance, or further details - reach out!

## Technical details for the curious:

The underlying index of plugins is published as a JSON file at https://github.com/HexRaysSA/plugin-repository, and Hex-Rays maintains [https://plugins.hex-rays.com/](https://plugins.hex-rays.com/) as a website showing the available plugins (As of October 9, 2025, the updated website has not been deployed, though it is pending). 

HCLI is a Python CLI program that can download, install, and configure IDA Pro, including searching, fetching, and upgrading plugins. During installation, HCLI places plugins into the correct locations, and install Python dependencies, handles centralized configurations, and more. You can read and contribute to the [source here](https://github.com/HexRaysSA/ida-hcli/tree/main).

We have some further technical documentation here:

- [Plugin packaging and format](https://github.com/HexRaysSA/ida-hcli/blob/main/docs/reference/plugin-packaging-and-format.md)
- [Plugin repository architecture](https://github.com/HexRaysSA/ida-hcli/blob/main/docs/reference/plugin-repository-architecture.md)
- [Porting your existing plugin](https://github.com/HexRaysSA/ida-hcli/blob/main/docs/reference/porting-your-existing-plugin.md)

Here's how a user interacts with the plugin manager via HCLI:

```console
❯ hcli plugin search
current platform: macos-aarch64
current version: 9.2

 bindiff                8.0.0      installed              
 binexport              12.0.0     installed              
 bookmark-hints         0.1.3                             
 capa (incompatible)    9.2.1                             
 colorize-calls         0.1.3                            
 comida (incompatible)  2025.9.24                         
 deREferencing          2025.9.24  installed              
 extensible-hints       0.1.3                             
 hint-calls             0.1.3      upgradable from 0.1.2 
 ida-terminal-plugin    0.0.6      upgradable from 0.0.5  
 IFL                    1.5.2      installed              
 ipyida                 2.3        installed              
 oplog                  0.1.3      installed              
 tag-func               0.1.3                             
 xray                   2025.9.24                         
 
❯ hcli plugin install hint-calls
Installed plugin: hint-calls==0.1.3

❯ hcli plugin status
 hint-calls            0.1.3
 oplog                 0.1.3
 HashDB                1.10.0     not found in repository
 DelphiHelper          1.21       not found in repository
 ipyida                2.3
 bindiff               8.0.0
 deREferencing         2025.9.24
 binexport             12.0.0
 IFL                   1.5.2
 ida-terminal-plugin   0.0.5      upgradable to 0.0.6
 (incompatible) yarka  0.7.0      found at: $IDAPLUGINS/yarka/
 (legacy) foo.py                  found at: $IDAPLUGINS/foo.py

Incompatible plugins don't work with this version of hcli.
They might be broken or outdated. Try using `hcli plugin lint /path/to/plugin`.

Legacy plugins are old, single-file plugins.
They aren't managed by hcli. Try finding an updated version in the plugin repository.
```